### PR TITLE
Implement Point Light, update quicktest.py to include a Point Light

### DIFF
--- a/quicktest.py
+++ b/quicktest.py
@@ -2,7 +2,7 @@
 
 import math
 import os
-from term3d.core import term3d, Vec3
+from term3d.core import term3d, Vec3, PointLight
 from term3d.shpbuild import build_cube, build_uv_sphere, build_cylinder, build_torus
 from term3d.utils import set_mat
 try:
@@ -53,8 +53,16 @@ class OrbitScene:
         self.engine.set_render_quality(q)
 
         self.engine.set_clear_color(20,30,40) 
-        self.engine.add_light(Vec3(0.5, 0.7, -1.0), (255, 255, 255), 1.0)
-        self.engine.set_ambient_light(80,80,80) 
+        self.engine.add_light(Vec3(0.5, 0.7, -1.0), (255, 255, 255), 0.4)       # Make it low for now
+
+        # Add a point light, focus on the circle orbiting, if it become dark near siting between the cube and camera and lit(color toward orange) siting opposite the camera, the PointLight work!
+        point_light_pos = Vec3(0, 0, 0)   # I add a point light in center for testing
+        point_light_color = (255, 210, 150)
+        point_light_intensity = 1.0
+        new_point_light = PointLight(point_light_pos, point_light_color, point_light_intensity)
+        self.engine.lights.append(new_point_light)
+
+        self.engine.set_ambient_light(60,60,60)    
 
         self.orbit_angle_sphere = 0.0
         self.orbit_angle_cylinder = math.pi / 2  

--- a/term3d/objects.py
+++ b/term3d/objects.py
@@ -1,0 +1,102 @@
+import math
+from .vec3lib import Vec3
+class Light:
+    """Represents a directional light source with color and intensity."""
+    def __init__(self, direction, color, intensity):
+        self.direction = direction.norm()
+        self.color = color
+        self.intensity = intensity
+
+class SpotLight:
+    """Represents a spotlight (cone light) with position, direction, and cutoff angles."""
+    def __init__(self, position, direction, color, intensity=1.0, inner_angle=15.0, outer_angle=20.0):
+        self.position = position          # Vec3
+        self.direction = direction.norm() # Vec3
+        self.color = color                # (r,g,b)
+        self.intensity = intensity
+        self.inner_angle = math.radians(inner_angle)
+        self.outer_angle = math.radians(outer_angle)
+
+    def cone_factor(self, frag_pos):
+        """Return factor 0..1 depending on if frag_pos is inside the cone."""
+        L = (frag_pos - self.position).norm()
+        cos_theta = self.direction.dot(-L)
+
+        cos_inner = math.cos(self.inner_angle)
+        cos_outer = math.cos(self.outer_angle)
+
+        if cos_theta < cos_outer:
+            return 0.0
+        if cos_theta > cos_inner:
+            return 1.0
+        # Smooth falloff
+        return (cos_theta - cos_outer) / (cos_inner - cos_outer)
+
+    def attenuation(self, frag_pos):
+        """Simple distance-based falloff (inverse-square)."""
+        dist = (frag_pos - self.position).length()
+        # Avoid division by zero
+        return 1.0 / (1.0 + 0.1 * dist + 0.02 * (dist * dist))
+
+class PointLight:
+    """Represents a point light with position, color, and intensity."""
+    def __init__(self, position, color, intensity=1.0):
+        self.position = position  # Vec3
+        self.color = color        # (r,g,b)
+        self.intensity = intensity
+
+    def attenuation(self, frag_pos):
+        """Simple distance-based falloff (inverse-square)."""
+        dist = (frag_pos - self.position).length()
+        # Avoid division by zero
+        return 1.0 / (1.0 + 0.1 * dist + 0.02 * (dist * dist))
+
+# Mesh and Scene classes
+class Mesh:
+    def __init__(self, verts, faces, colors, material='flat'):
+        self.verts = verts
+        self.faces = faces
+        self.vcols = colors
+        self.material = material  # 'flat', 'phong', 'wireframe'
+        self.pos = Vec3(0, 0, 0)
+        self.rot = Vec3(0, 0, 0)
+        self.scale = Vec3(1, 1, 1)
+
+    def move(self, x=0, y=0, z=0):
+        self.pos.x += x
+        self.pos.y += y
+        self.pos.z += z
+
+    def rotate(self, x=0, y=0, z=0):
+        self.rot.x += x
+        self.rot.y += y
+        self.rot.z += z
+        
+    def calculate_bounds(self):
+        """Calculates the axis-aligned bounding box (AABB) for the mesh."""
+        if not self.verts:
+            return
+
+        min_x = min(v.x for v in self.verts)
+        min_y = min(v.y for v in self.verts)
+        min_z = min(v.z for v in self.verts)
+
+        max_x = max(v.x for v in self.verts)
+        max_y = max(v.y for v in self.verts)
+        max_z = max(v.z for v in self.verts)
+
+        self.min_v = Vec3(min_x, min_y, min_z)
+        self.max_v = Vec3(max_x, max_y, max_z)
+        
+
+class Camera:
+    """
+    Represents the camera, handling projection settings, position, and rotation.
+    """
+    def __init__(self, fov=60.0, znear=0.1, zfar=100.0, zoom=3.0):
+        self.fov = fov
+        self.znear = znear
+        self.zfar = zfar
+        self.zoom = zoom
+        self.pos = Vec3(0, 0, 0)
+        self.rot = Vec3(0, 0, 0) # Pitch, Yaw, Roll


### PR DESCRIPTION
# Add Point Light Support to Term3D

## Overview
This PR introduces a **Point Light** feature to Term3D with an API, updates `quicktest.py` to include a Point Light and chage the debug menu to display `Lights` more specifically

## Changes
- Moved all objects class to `objects.py`
- Added `PointLight` class in `objects.py`.
- Updated `quicktest.py` to include a simple test scene demonstrating the Point Light.
- Chage the debug menu `Lights` section to show light types and all of it's available property
<img width="1111" height="879" alt="image" src="https://github.com/user-attachments/assets/e7329e4b-6b5c-403d-93d1-5c289a3383f4" />

## How to Test
1. Run `quicktest.py`:
```bash
python quicktest.py
```
## Related Issue
Closes #3 